### PR TITLE
chore: update Uno SDK and remove workaround in project file

### DIFF
--- a/src/Stopwatch/Stopwatch.csproj
+++ b/src/Stopwatch/Stopwatch.csproj
@@ -35,11 +35,6 @@
 
 	<PropertyGroup Condition="'$(TargetFramework)'=='net9.0-browserwasm'">
 		<WasmShellEnableIDBFS>true</WasmShellEnableIDBFS>
-		<!-- Temporary workaround for Uno.Wasm.Bootstrap -->
-		<UnoGenerateAssetsManifestDependsOn>
-			$(UnoGenerateAssetsManifestDependsOn);
-			GenerateUnoWasmAssets;
-		</UnoGenerateAssetsManifestDependsOn>
 	</PropertyGroup>
 	
 	<ItemGroup>

--- a/src/global.json
+++ b/src/global.json
@@ -3,6 +3,6 @@
     "allowPrerelease": false
   },
 	"msbuild-sdks": {
-		"Uno.Sdk": "5.7.0-dev.187"
+		"Uno.Sdk": "6.0.0-dev.159"
 	}
 }


### PR DESCRIPTION
chore: update Uno SDK and remove workaround in project file

- Removed the temporary workaround for `Uno.Wasm.Bootstrap` in `Stopwatch.csproj`, indicating improved compatibility or stability.
- Upgraded `Uno.Sdk` version in `global.json` from `5.7.0-dev.187` to `6.0.0-dev.159` for potential new features and bug fixes.