### PR TITLE
perf: Use `MinBy/MaxBy` instead of `OrderBy().FirstOrDefault()`

### DIFF
--- a/src/Stopwatch/ViewModels/LapsObservableCollection.cs
+++ b/src/Stopwatch/ViewModels/LapsObservableCollection.cs
@@ -60,8 +60,8 @@ public class LapsObservableCollection : ObservableCollection<LapViewModel>
 	{
 		if (Count >= 2)
 		{
-			var fastest = this.OrderBy(l => l.LapTime).FirstOrDefault();
-			var slowest = this.OrderByDescending(l => l.LapTime).FirstOrDefault();
+			var fastest = Enumerable.MinBy(this, l => l.LapTime);
+			var slowest = Enumerable.MaxBy(this, l => l.LapTime);
 
 			foreach (var lap in this)
 			{


### PR DESCRIPTION
Replaced O(n log n) sorting operations with O(n) MinBy/MaxBy methods to find fastest and slowest laps in LapsObservableCollection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)