### PR TITLE
fix: Add error handling to async void `ViewNavigatedTo` methods

### DIFF
--- a/src/Stopwatch/ViewModels/GetProViewModel.cs
+++ b/src/Stopwatch/ViewModels/GetProViewModel.cs
@@ -21,10 +21,17 @@ public partial class GetProViewModel : PageViewModel
 
 	public override async void ViewNavigatedTo(object? parameter)
 	{
-		var price = await _storeService.GetPriceAsync();
-		if (price is not null)
+		try
 		{
-			CurrentPrice = price;
+			var price = await _storeService.GetPriceAsync();
+			if (price is not null)
+			{
+				CurrentPrice = price;
+			}
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"Error in ViewNavigatedTo: {ex.Message}");
 		}
 	}
 

--- a/src/Stopwatch/ViewModels/MainViewModel.cs
+++ b/src/Stopwatch/ViewModels/MainViewModel.cs
@@ -78,13 +78,20 @@ public partial class MainViewModel : PageViewModel
 
 	public override async void ViewNavigatedTo(object? parameter)
 	{
-		ReloadStopwatches();
-		HasProLicense = await _storeService.HasProAsync();
-
-		// Show teaching tips for first-time users or when returning from settings
-		if (!_appPreferences.HasSeenOnboardingTips)
+		try
 		{
-			TriggerTeachingTips?.Invoke();
+			ReloadStopwatches();
+			HasProLicense = await _storeService.HasProAsync();
+
+			// Show teaching tips for first-time users or when returning from settings
+			if (!_appPreferences.HasSeenOnboardingTips)
+			{
+				TriggerTeachingTips?.Invoke();
+			}
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"Error in ViewNavigatedTo: {ex.Message}");
 		}
 	}
 

--- a/src/Stopwatch/ViewModels/SettingsViewModel.cs
+++ b/src/Stopwatch/ViewModels/SettingsViewModel.cs
@@ -99,6 +99,10 @@ public partial class SettingsViewModel : PageViewModel
 				BackgroundColor = ColorHelper.ToColor(_stopwatch.BackgroundColor);
 			}
 		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Debug.WriteLine($"Error in ViewNavigatedTo: {ex.Message}");
+		}
 		finally
 		{
 			_isInitializing = false;


### PR DESCRIPTION
Wrapped async void ViewNavigatedTo methods in try-catch blocks to prevent unhandled exceptions from crashing the app. Affected ViewModels:
- MainViewModel
- GetProViewModel
- SettingsViewModel (added catch to existing try-finally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)