### PR TITLE
fix: Add `IDisposable` to `ThemeManager` to prevent memory leak

### DIFF
--- a/src/Stopwatch/Services/Theming/IThemeManager.cs
+++ b/src/Stopwatch/Services/Theming/IThemeManager.cs
@@ -1,6 +1,6 @@
 ﻿namespace Stopwatch.Services.Theming;
 
-public interface IThemeManager
+public interface IThemeManager : IDisposable
 {
 	void SetTheme(ElementTheme theme);
 

--- a/src/Stopwatch/Services/Theming/ThemeManager.cs
+++ b/src/Stopwatch/Services/Theming/ThemeManager.cs
@@ -80,4 +80,9 @@ public class ThemeManager : IThemeManager
 			UpdateTitleBarTheming();
 		});
 	}
+
+	public void Dispose()
+	{
+		_uiSettings.ColorValuesChanged -= OnColorValuesChanged;
+	}
 }


### PR DESCRIPTION
UISettings.ColorValuesChanged was subscribed but never unsubscribed, causing a memory leak. Added IDisposable to IThemeManager interface and implemented Dispose() in ThemeManager to unsubscribe from the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)