### PR TITLE
fix: Recognize Pro add-on license on Windows (InAppOfferToken)

### DIFF
--- a/src/Stopwatch/Services/Store/StoreService.Windows.cs
+++ b/src/Stopwatch/Services/Store/StoreService.Windows.cs
@@ -13,7 +13,11 @@ namespace Stopwatch.Services.Store;
 
 public class StoreService : IStoreService
 {
+	// Store ID — used for purchase and price queries (RequestPurchaseAsync / GetStoreProductsAsync).
 	private const string StopwatchProId = "9PJRM3NWXGBN";
+
+	// Partner Center product ID — used to identify our add-on's license via StoreLicense.InAppOfferToken.
+	private const string StopwatchProProductId = "StopwatchPro";
 
 	private readonly IWindowShellProvider _shellProvider;
 	private readonly IDialogService _dialogService;
@@ -55,7 +59,13 @@ public class StoreService : IStoreService
 		{
 			var context = GetStoreContext();
 			var result = await context.GetAppLicenseAsync();
-			_hasPro = result.AddOnLicenses.Any(license => license.Value.SkuStoreId == StopwatchProId);
+			// A durable add-on's license is present in AddOnLicenses only while the user is
+			// entitled (expired/invalid licenses are removed), so membership signals ownership.
+			// Identify our add-on by its Partner Center product ID via InAppOfferToken — the
+			// documented way to match a specific add-on. Don't gate on StoreLicense.IsActive:
+			// it is reserved for future use and currently always returns true.
+			_hasPro = result.AddOnLicenses.Values.Any(license =>
+				license.InAppOfferToken == StopwatchProProductId);
 		}
 
 		return _hasPro.Value;


### PR DESCRIPTION
## Problem

The Windows `StoreService` checked `AddOnLicenses.Any(l => l.Value.SkuStoreId == StopwatchProId)` where `StopwatchProId = "9PJRM3NWXGBN"` (the 12-char **product** Store ID). But `StoreLicense.SkuStoreId` is the **SKU** Store ID, formatted `"<productStoreId>/<sku>"` (e.g. `9PJRM3NWXGBN/0010`), so the comparison **never matches** on a fresh launch.

Pro therefore only worked in the session where it was purchased (`TryPurchaseProAsync` sets `_hasPro = true` in memory) and **silently reverted on the next launch**. The bug has existed since the store service was first added (2024‑09‑23); it's gone unreported only because the Pro gate (opening a 3rd simultaneous stopwatch) is rarely hit and Pro is primarily sold on mobile via RevenueCat.

## Fix

Match the add-on by its Partner Center **product ID** via `StoreLicense.InAppOfferToken == "StopwatchPro"` — the Microsoft-documented way to identify a specific add-on's license. Entitlement is signalled by **membership** in `AddOnLicenses` (expired/invalid licenses are removed); `StoreLicense.IsActive` is reserved for future use and always returns `true`, so it is not used. The `9PJRM3NWXGBN` Store ID is retained — it's still required by `RequestPurchaseAsync` / `GetStoreProductsAsync`.

Bonus: `TryRestorePurchasesAsync` now actually restores Pro (it previously re-ran the same broken check).

## Context

Mirrors **MartinZikmund/Awaitick#481** — discovered while triaging Awaitick's first-release feedback (a paying user lost Pro after a restart). The identical code was copied between the two apps.

## Refs
- https://learn.microsoft.com/windows/uwp/monetize/get-license-info-for-apps-and-add-ons
- https://learn.microsoft.com/uwp/api/windows.services.store.storelicense.inappoffertoken
- https://learn.microsoft.com/windows/uwp/monetize/in-app-purchases-and-trials#store-ids

## Verification
Single-property change mirroring the compile-verified Awaitick fix; a local Windows-head build is running and I'll confirm. Final runtime proof needs a Store-signed build with the real purchased add-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GBXd73Wq2HamdqAur5AWV
